### PR TITLE
pregunta sobre insignia de ponente

### DIFF
--- a/marketing/wordcamp/preguntas/index.md
+++ b/marketing/wordcamp/preguntas/index.md
@@ -1,11 +1,12 @@
 # Preguntas frecuentes
 
-## La insignia de Ponente no aparece en el perfil de WordPress tras finalizar la WordCamp
+## ¿Como conseguir la insignia de ponente en una WordCamp si ha sido tu primera ponencia?
 
-Tras mi primera ponencia en Madrid no aparece la insignia de WordCamp Speaker.
-En este caso, la forma correcta de actuar debe ser la siguiente:
+Tras realizar un colaborador de WordPress por vez primera una ponencia en una WordCamp, en ocasiones, no aparece la insignia en su perfil de WordPress.org.
+Para que este error del sistema se solvente, se debe realizar la siguientes acciones.
 
-- Entrar en la ficha de la WordCamp del ponente.
-- Darle a guardar de nuevo, validando que el nombre de usuario sea el correcto.
+1. Entrar en la web de la WordCamp donde el colaborador ha realizado la ponencia.
+2. Buscar la ficha del ponente por su nombre y hacer clic en guardar.
+3. Refrescar o actualizar la web.
 
-Con estos sencillos pasos se queda actualizado el perfil del ponente.
+Siguiendo esta sencilla guía, el colaborador obtendrá en su perfil de WordPress.org, de forma automática, la insignia de ponente en WordCamp.


### PR DESCRIPTION
Realizado texto para contestar la pregunta sobre como actualizar el perfil de un ponente tras una WordCamp y que aparezca la insignia en el perfil de WordPress.